### PR TITLE
Filter out @ symbols from nicks when grabbing

### DIFF
--- a/QuoteGrabs/plugin.py
+++ b/QuoteGrabs/plugin.py
@@ -362,7 +362,7 @@ class QuoteGrabs(callbacks.Plugin):
         # opposed to channel which is used to determine which db to store the
         # quote in
         chan = msg.args[0]
-        nick = nick.replace('@', '')
+        nick = nick.lstrip('@')
         if chan is None:
             raise callbacks.ArgumentError
         if ircutils.nickEqual(nick, msg.nick):

--- a/QuoteGrabs/plugin.py
+++ b/QuoteGrabs/plugin.py
@@ -362,6 +362,7 @@ class QuoteGrabs(callbacks.Plugin):
         # opposed to channel which is used to determine which db to store the
         # quote in
         chan = msg.args[0]
+        nick = nick.replace('@', '')
         if chan is None:
             raise callbacks.ArgumentError
         if ircutils.nickEqual(nick, msg.nick):


### PR DESCRIPTION
Recently slack started autocompleting names and including the @, which breaks the grabber.
I have no idea if this actually works.